### PR TITLE
Adding buddybuild status badge

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -1,5 +1,5 @@
 
-# FlappySwift
+# FlappySwift test
 
 [![BuddyBuild](https://dashboard.buddybuild.com/api/statusImage?appID=55dd277abbda430100397040&branch=master&build=latest)](https://dashboard.buddybuild.com/apps/55dd277abbda430100397040/build/latest)
 


### PR DESCRIPTION
We really liked Flappyswift and wanted to offer you a free continuous integration system [buddybuild](buddybuild.com) to make sure that your app always works!

If this sounds like something that may be helpful, setup is really simple and we've already taken most of the steps for you…[here](https://dashboard.buddybuild.com/apps/565638c453d9f7010011b076/build/565638f453d9f7010011b078) are the builds we've completed for FlappySwift so far.

To configure your builds and to to make sure we kick off a new build with every commit you make, simply login [here](dashboard.buddybuild.com).

Finally, if you’d like to know the latest build status of your app directly from your repo page, we offer small status badges - like the one seen on the [flappyswift](https://github.com/fullstackio/FlappySwift) repo.

To help add these, we created this pull request by adding a couple of lines to the readme.

If you have any questions or would like to learn more about buddybuild, feel free to email team@buddybuild.com directly or use the Intercom button on the website.